### PR TITLE
Add transformer for RAE conjugations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ produce audio using ElevenLabs.
 - `generate_audio.py` creates audio files for the sentences with
   ElevenLabs.
 - `get_conjugation_rae.py` scrapes conjugations from the RAE dictionary
-  website and outputs them in the project's JSON format.
+  website and outputs them in the project's JSON format. Reflexive verbs
+  are handled automatically by removing the trailing pronoun before
+  fetching.
 - `regular_form_generator.py` provides hypothetical regular forms used to
   flag irregular conjugations.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ produce audio using ElevenLabs.
 - `generate_audio.py` creates audio files for the sentences with
   ElevenLabs.
 - `get_conjugation_rae.py` scrapes conjugations from the RAE dictionary
-  website.
+  website and outputs them in the project's JSON format.
 - `regular_form_generator.py` provides hypothetical regular forms used to
   flag irregular conjugations.
 

--- a/get_conjugation_rae.py
+++ b/get_conjugation_rae.py
@@ -239,16 +239,21 @@ class RAEConjugationTransformer:
             original = form
             if pron == "nos" and form.endswith("mos"):
                 form = form[:-1]
+                result = form + pron
             elif pron == "os" and form.endswith("d"):
                 trimmed = form[:-1]
                 if base == "ir" and original == "id":
                     return "idos"
                 if ending == "ir" and trimmed.endswith("i"):
                     trimmed = trimmed[:-1] + "í"
-                form = trimmed
-            result = form + pron
+                result = trimmed + pron
+                return result
+            else:
+                result = form + pron
+
             if any(c in ACCENTS for c in original):
                 return result
+
             orig_idx = self._stress_index(original)
             new_default = self._stress_index(result.translate(ACCENT_REVERSE))
             if orig_idx != new_default:

--- a/get_conjugation_rae.py
+++ b/get_conjugation_rae.py
@@ -185,6 +185,10 @@ class RAEConjugationTransformer:
         imperativo = data.get("Imperativo", {})
         if "Imperativo" in imperativo:
             out["imperativo_affirmativo"] = self._map_personal(imperativo["Imperativo"])
+            if "1st_plural" not in out["imperativo_affirmativo"]:
+                subj = out.get("subjuntivo_presente")
+                if isinstance(subj, dict) and "1st_plural" in subj:
+                    out["imperativo_affirmativo"]["1st_plural"] = subj["1st_plural"]
 
         subj_pres = out.get("subjuntivo_presente")
         if subj_pres:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 cloudscraper
 beautifulsoup4
 pytest
+pyphen

--- a/tests/test_conjugation.py
+++ b/tests/test_conjugation.py
@@ -92,6 +92,7 @@ def test_hablar():
     assert gen.generate("hablar", "imperativo_negativo", "2nd_plural") == "no habléis"
     assert gen.generate("hablar", "imperativo_negativo", "3rd_plural") == "no hablen"
 
+
 def test_deber():
     # Non-personal forms
     assert gen.generate("deber", "infinitivo", "not_applicable") == "deber"
@@ -175,6 +176,7 @@ def test_deber():
     assert gen.generate("deber", "imperativo_negativo", "1st_plural") == "no debamos"
     assert gen.generate("deber", "imperativo_negativo", "2nd_plural") == "no debáis"
     assert gen.generate("deber", "imperativo_negativo", "3rd_plural") == "no deban"
+
 
 def test_vivir():
     # Non-personal forms
@@ -260,6 +262,7 @@ def test_vivir():
     assert gen.generate("vivir", "imperativo_negativo", "2nd_plural") == "no viváis"
     assert gen.generate("vivir", "imperativo_negativo", "3rd_plural") == "no vivan"
 
+
 def test_oír():
     # Non-personal forms
     assert gen.generate("oír", "infinitivo", "not_applicable") == "oír"
@@ -343,6 +346,7 @@ def test_oír():
     assert gen.generate("oír", "imperativo_negativo", "1st_plural") == "no oamos"
     assert gen.generate("oír", "imperativo_negativo", "2nd_plural") == "no oáis"
     assert gen.generate("oír", "imperativo_negativo", "3rd_plural") == "no oan"
+
 
 def test_levantarse():
     # Non-personal forms
@@ -582,6 +586,7 @@ def test_levantarse():
         == "no se levanten"
     )
 
+
 def test_reírse():
     # Non-personal forms
     assert gen.generate("reírse", "infinitivo", "not_applicable") == "reírse"
@@ -680,6 +685,7 @@ def test_reírse():
     assert gen.generate("reírse", "imperativo_negativo", "2nd_plural") == "no os reáis"
     assert gen.generate("reírse", "imperativo_negativo", "3rd_plural") == "no se rean"
 
+
 def test_irse():
     # Non-personal forms
     assert gen.generate("irse", "infinitivo", "not_applicable") == "irse"
@@ -763,6 +769,7 @@ def test_irse():
     assert gen.generate("irse", "imperativo_negativo", "1st_plural") == "no nos amos"
     assert gen.generate("irse", "imperativo_negativo", "2nd_plural") == "no os áis"
     assert gen.generate("irse", "imperativo_negativo", "3rd_plural") == "no se an"
+
 
 def test_meterse():
     # Non-personal forms

--- a/tests/test_conjugation.py
+++ b/tests/test_conjugation.py
@@ -545,15 +545,15 @@ def test_levantarse():
     # Imperativo afirmativo (no 1st person singular)
     assert (
         gen.generate("levantarse", "imperativo_affirmativo", "2nd_singular")
-        == "levantate"
+        == "levántate"
     )
     assert (
         gen.generate("levantarse", "imperativo_affirmativo", "3rd_singular")
-        == "levantese"
+        == "levántese"
     )
     assert (
         gen.generate("levantarse", "imperativo_affirmativo", "1st_plural")
-        == "levantemosnos"
+        == "levantémonos"
     )
     assert (
         gen.generate("levantarse", "imperativo_affirmativo", "2nd_plural")
@@ -561,7 +561,7 @@ def test_levantarse():
     )
     assert (
         gen.generate("levantarse", "imperativo_affirmativo", "3rd_plural")
-        == "levantense"
+        == "levántense"
     )
 
     # Imperativo negativo (no 1st person singular)
@@ -670,11 +670,11 @@ def test_reírse():
     assert gen.generate("reírse", "subjuntivo_futuro", "3rd_plural") == "se reieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("reírse", "imperativo_affirmativo", "2nd_singular") == "reete"
-    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_singular") == "rease"
-    assert gen.generate("reírse", "imperativo_affirmativo", "1st_plural") == "reamosnos"
+    assert gen.generate("reírse", "imperativo_affirmativo", "2nd_singular") == "ríete"
+    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_singular") == "ríase"
+    assert gen.generate("reírse", "imperativo_affirmativo", "1st_plural") == "riámonos"
     assert gen.generate("reírse", "imperativo_affirmativo", "2nd_plural") == "reíos"
-    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_plural") == "reanse"
+    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_plural") == "ríanse"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("reírse", "imperativo_negativo", "2nd_singular") == "no te reas"
@@ -757,11 +757,11 @@ def test_irse():
     assert gen.generate("irse", "subjuntivo_futuro", "3rd_plural") == "se ieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("irse", "imperativo_affirmativo", "2nd_singular") == "ete"
-    assert gen.generate("irse", "imperativo_affirmativo", "3rd_singular") == "ase"
-    assert gen.generate("irse", "imperativo_affirmativo", "1st_plural") == "amosnos"
+    assert gen.generate("irse", "imperativo_affirmativo", "2nd_singular") == "vete"
+    assert gen.generate("irse", "imperativo_affirmativo", "3rd_singular") == "váyase"
+    assert gen.generate("irse", "imperativo_affirmativo", "1st_plural") == "vámonos"
     assert gen.generate("irse", "imperativo_affirmativo", "2nd_plural") == "idos"
-    assert gen.generate("irse", "imperativo_affirmativo", "3rd_plural") == "anse"
+    assert gen.generate("irse", "imperativo_affirmativo", "3rd_plural") == "váyanse"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("irse", "imperativo_negativo", "2nd_singular") == "no te as"
@@ -876,13 +876,13 @@ def test_meterse():
     assert gen.generate("meterse", "subjuntivo_futuro", "3rd_plural") == "se metieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("meterse", "imperativo_affirmativo", "2nd_singular") == "metete"
-    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_singular") == "metase"
+    assert gen.generate("meterse", "imperativo_affirmativo", "2nd_singular") == "métete"
+    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_singular") == "métase"
     assert (
-        gen.generate("meterse", "imperativo_affirmativo", "1st_plural") == "metamosnos"
+        gen.generate("meterse", "imperativo_affirmativo", "1st_plural") == "metámonos"
     )
     assert gen.generate("meterse", "imperativo_affirmativo", "2nd_plural") == "meteos"
-    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_plural") == "metanse"
+    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_plural") == "métanse"
 
     # Imperativo negativo (no 1st person singular)
     assert (

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -54,5 +54,5 @@ def test_reflexive_transform():
     assert out["gerundio"] == "metiéndose"
     assert out["participio"] == ""
     assert out["indicativo_presente"]["1st_singular"] == "me meto"
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "metete"
+    assert out["imperativo_affirmativo"]["2nd_singular"] == "métete"
     assert out["imperativo_negativo"]["2nd_singular"] == "no te metas"

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -46,6 +46,22 @@ RAW = {
     },
 }
 
+RAW_QUEDAR = {
+    "Formas no personales": {
+        "Infinitivo": {"": "quedar"},
+        "Gerundio": {"": "quedando"},
+        "Participio": {"": "quedado"},
+    },
+    "Imperativo": {
+        "Imperativo": {
+            "tú": "queda",
+            "usted": "quede",
+            "vosotros, vosotras": "quedad",
+            "ustedes": "queden",
+        }
+    },
+}
+
 
 def test_reflexive_transform():
     transformer = RAEConjugationTransformer("meterse", is_reflexive=True)
@@ -56,3 +72,9 @@ def test_reflexive_transform():
     assert out["indicativo_presente"]["1st_singular"] == "me meto"
     assert out["imperativo_affirmativo"]["2nd_singular"] == "métete"
     assert out["imperativo_negativo"]["2nd_singular"] == "no te metas"
+
+
+def test_second_plural_no_accent():
+    transformer = RAEConjugationTransformer("quedarse", is_reflexive=True)
+    out = transformer.transform(RAW_QUEDAR)
+    assert out["imperativo_affirmativo"]["2nd_plural"] == "quedaos"

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import json
+from get_conjugation_rae import RAEConjugationTransformer
+
+RAW = {
+    "Formas no personales": {
+        "Infinitivo": {"": "meter"},
+        "Gerundio": {"": "metiendo"},
+        "Participio": {"": "metido"},
+    },
+    "Indicativo": {
+        "Presente": {
+            "yo": "meto",
+            "tú": "metes",
+            "usted": "mete",
+            "él, ella": "mete",
+            "nosotros, nosotras": "metemos",
+            "vosotros, vosotras": "metéis",
+            "ustedes": "meten",
+            "ellos, ellas": "meten",
+        }
+    },
+    "Subjuntivo": {
+        "Presente": {
+            "yo": "meta",
+            "tú": "metas",
+            "usted": "meta",
+            "él, ella": "meta",
+            "nosotros, nosotras": "metamos",
+            "vosotros, vosotras": "metáis",
+            "ustedes": "metan",
+            "ellos, ellas": "metan",
+        }
+    },
+    "Imperativo": {
+        "Imperativo": {
+            "tú": "mete",
+            "usted": "meta",
+            "vosotros, vosotras": "meted",
+            "ustedes": "metan",
+        }
+    },
+}
+
+
+def test_reflexive_transform():
+    transformer = RAEConjugationTransformer("meterse", is_reflexive=True)
+    out = transformer.transform(RAW)
+    assert out["infinitivo"] == "meterse"
+    assert out["gerundio"] == "metiéndose"
+    assert out["participio"] == ""
+    assert out["indicativo_presente"]["1st_singular"] == "me meto"
+    assert out["imperativo_affirmativo"]["2nd_singular"] == "metete"
+    assert out["imperativo_negativo"]["2nd_singular"] == "no te metas"


### PR DESCRIPTION
## Summary
- parse RAE conjugation output into project format
- transform and print JSON in `get_conjugation_rae.py`
- document RAE transformer usage

## Testing
- `black --check .`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684c201bf3348329a01095417e9da3f7