### PR TITLE
Fix syllable detection for accent placement

### DIFF
--- a/tests/test_conjugation_regularity_classifier.py
+++ b/tests/test_conjugation_regularity_classifier.py
@@ -63,3 +63,11 @@ def test_i_to_y():
 def test_written_accent_shift():
     forms = {"indicativo_presente": {"1st_singular": "envío"}}
     assert classifier.classify("enviar", forms) == "orthographically_irregular"
+
+def test_reflexive_imperative_levantarse():
+    forms = {"imperativo_affirmativo": {"2nd_singular": "levántate"}}
+    assert classifier.classify("levantarse", forms) == "regular"
+
+def test_reflexive_imperative_echarse():
+    forms = {"imperativo_affirmativo": {"2nd_singular": "échate"}}
+    assert classifier.classify("echarse", forms) == "regular"

--- a/tests/test_get_conjugation_rae_reflexive_fusing.py
+++ b/tests/test_get_conjugation_rae_reflexive_fusing.py
@@ -7,6 +7,7 @@ from utilities.get_conjugation_rae import RAEConjugationFetcher
 from utilities.get_conjugation_rae import RAEConjugationTransformer
 from utilities.get_conjugation_rae import strip_reflexive
 
+
 def test_arrepentirse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("arrepentirse")
@@ -22,6 +23,7 @@ def test_arrepentirse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "arrepintámonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "arrepentíos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "arrepiéntanse"
+
 
 def test_bajarse():
     fetcher = RAEConjugationFetcher()
@@ -39,6 +41,7 @@ def test_bajarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "bajaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "bájense"
 
+
 def test_bañarse():
     fetcher = RAEConjugationFetcher()
     raw = fetcher.get_conjugation("bañar")
@@ -54,6 +57,7 @@ def test_bañarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "bañaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "báñense"
 
+
 def test_darse():
     fetcher = RAEConjugationFetcher()
     raw = fetcher.get_conjugation("dar")
@@ -68,6 +72,7 @@ def test_darse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "démonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "daos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "dense"
+
 
 def test_echarse():
     fetcher = RAEConjugationFetcher()
@@ -85,6 +90,7 @@ def test_echarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "echaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "échense"
 
+
 def test_endeudarse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("endeudarse")
@@ -100,6 +106,7 @@ def test_endeudarse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "endeudémonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "endeudaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "endéudense"
+
 
 def test_esforzarse():
     fetcher = RAEConjugationFetcher()
@@ -117,6 +124,7 @@ def test_esforzarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "esforzaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "esfuércense"
 
+
 def test_fijarse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("fijarse")
@@ -132,6 +140,7 @@ def test_fijarse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "fijémonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "fijaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "fíjense"
+
 
 def test_irse():
     fetcher = RAEConjugationFetcher()
@@ -149,6 +158,7 @@ def test_irse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "idos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "váyanse"
 
+
 def test_levantarse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("levantarse")
@@ -165,6 +175,7 @@ def test_levantarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "levantaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "levántense"
 
+
 def test_liarse():
     fetcher = RAEConjugationFetcher()
     raw = fetcher.get_conjugation("liar")
@@ -179,6 +190,7 @@ def test_liarse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "liémonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "liaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "líense"
+
 
 def test_meterse():
     fetcher = RAEConjugationFetcher()
@@ -196,6 +208,7 @@ def test_meterse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "meteos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "métanse"
 
+
 def test_quedarse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("quedarse")
@@ -211,6 +224,7 @@ def test_quedarse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "quedémonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "quedaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "quédense"
+
 
 def test_quejarse():
     fetcher = RAEConjugationFetcher()
@@ -228,6 +242,7 @@ def test_quejarse():
     assert out["imperativo_affirmativo"]["2nd_plural"] == "quejaos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "quéjense"
 
+
 def test_reírse():
     fetcher = RAEConjugationFetcher()
     base, is_reflexive = strip_reflexive("reírse")
@@ -243,6 +258,7 @@ def test_reírse():
     assert out["imperativo_affirmativo"]["1st_plural"] == "riámonos"
     assert out["imperativo_affirmativo"]["2nd_plural"] == "reíos"
     assert out["imperativo_affirmativo"]["3rd_plural"] == "ríanse"
+
 
 def test_subirse():
     fetcher = RAEConjugationFetcher()

--- a/tests/test_regular_form_generator.py
+++ b/tests/test_regular_form_generator.py
@@ -898,3 +898,13 @@ def test_meterse():
         gen.generate("meterse", "imperativo_negativo", "2nd_plural") == "no os metáis"
     )
     assert gen.generate("meterse", "imperativo_negativo", "3rd_plural") == "no se metan"
+
+
+def test_echarse_imperativo_affirmativo():
+    assert gen.generate("echarse", "imperativo_affirmativo", "2nd_singular") == "échate"
+    assert gen.generate("echarse", "imperativo_affirmativo", "3rd_singular") == "échese"
+    assert (
+        gen.generate("echarse", "imperativo_affirmativo", "1st_plural") == "echémonos"
+    )
+    assert gen.generate("echarse", "imperativo_affirmativo", "2nd_plural") == "echaos"
+    assert gen.generate("echarse", "imperativo_affirmativo", "3rd_plural") == "échense"

--- a/utilities/get_conjugation_rae.py
+++ b/utilities/get_conjugation_rae.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from typing import Dict, Iterable, Tuple
 
 import pyphen
@@ -174,7 +175,16 @@ class RAEConjugationTransformer:
         return text.strip()
 
     def _syllables(self, word: str) -> list[str]:
-        return _dic.inserted(word).split("-")
+        syls = _dic.inserted(word).split("-")
+        result: list[str] = []
+        for syl in syls:
+            parts = re.split(
+                r"(?<=[aeiouáéíóúü])(?=[^aeiouáéíóúü]+[aeiouáéíóúü])",
+                syl,
+                flags=re.IGNORECASE,
+            )
+            result.extend([p for p in parts if p])
+        return result
 
     def _stress_index(self, word: str) -> int:
         syls = self._syllables(word)

--- a/utilities/regular_form_generator.py
+++ b/utilities/regular_form_generator.py
@@ -1,3 +1,4 @@
+import re
 import pyphen
 
 ACCENTS = "áéíóú"
@@ -76,7 +77,16 @@ class RegularFormGenerator:
         return pronouns.get(person, "")
 
     def _syllables(self, word: str) -> list[str]:
-        return _dic.inserted(word).split("-")
+        syls = _dic.inserted(word).split("-")
+        result: list[str] = []
+        for syl in syls:
+            parts = re.split(
+                r"(?<=[aeiouáéíóúü])(?=[^aeiouáéíóúü]+[aeiouáéíóúü])",
+                syl,
+                flags=re.IGNORECASE,
+            )
+            result.extend([p for p in parts if p])
+        return result
 
     def _stress_index(self, word: str) -> int:
         syls = self._syllables(word)


### PR DESCRIPTION
## Summary
- improve syllable segmentation when calculating reflexive accents
- format tests with black

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df81589948329ad8e5c0da1b6b27a