### PR TITLE
Fix imperativo variable typo

### DIFF
--- a/generate_cards_init.py
+++ b/generate_cards_init.py
@@ -199,7 +199,7 @@ def generate_conjugation_table():
         ("hablar", "imperativo_negativo", "2nd_singular"),
         ("levantarse", "indicativo_presente", "1st_singular"),
         ("levantarse", "gerundio", "not_applicable"),
-        ("levantarse", "imperativo_affirmativo", "2nd_singular"),
+        ("levantarse", "imperativo_afirmativo", "2nd_singular"),
         ("levantarse", "imperativo_negativo", "2nd_singular"),
         ("ducharse", "indicativo_futuro", "3rd_plural"),
     ]

--- a/tests/test_conjugation_regularity_classifier.py
+++ b/tests/test_conjugation_regularity_classifier.py
@@ -64,10 +64,12 @@ def test_written_accent_shift():
     forms = {"indicativo_presente": {"1st_singular": "envío"}}
     assert classifier.classify("enviar", forms) == "orthographically_irregular"
 
+
 def test_reflexive_imperative_levantarse():
-    forms = {"imperativo_affirmativo": {"2nd_singular": "levántate"}}
+    forms = {"imperativo_afirmativo": {"2nd_singular": "levántate"}}
     assert classifier.classify("levantarse", forms) == "regular"
 
+
 def test_reflexive_imperative_echarse():
-    forms = {"imperativo_affirmativo": {"2nd_singular": "échate"}}
+    forms = {"imperativo_afirmativo": {"2nd_singular": "échate"}}
     assert classifier.classify("echarse", forms) == "regular"

--- a/tests/test_get_conjugation_rae.py
+++ b/tests/test_get_conjugation_rae.py
@@ -83,11 +83,11 @@ def test_amar():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "amaren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "ama"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "ame"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "amemos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "amad"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "amen"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "ama"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "ame"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "amemos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "amad"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "amen"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no ames"
@@ -172,11 +172,11 @@ def test_ser():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "fueren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "sé"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "sea"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "seamos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "sed"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "sean"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "sé"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "sea"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "seamos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "sed"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "sean"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no seas"
@@ -261,11 +261,11 @@ def test_recibir():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "recibieren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "recibe"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "reciba"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "recibamos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "recibid"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "reciban"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "recibe"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "reciba"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "recibamos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "recibid"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "reciban"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no recibas"
@@ -350,11 +350,11 @@ def test_oír():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "oyeren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "oye"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "oiga"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "oigamos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "oíd"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "oigan"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "oye"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "oiga"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "oigamos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "oíd"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "oigan"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no oigas"

--- a/tests/test_get_conjugation_rae_ar_reflexives.py
+++ b/tests/test_get_conjugation_rae_ar_reflexives.py
@@ -82,11 +82,11 @@ def test_darse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se dieren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "date"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "dese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "démonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "daos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "dense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "date"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "dese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "démonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "daos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "dense"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te des"
@@ -171,11 +171,11 @@ def test_liarse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se liaren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "líate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "líese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "liémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "liaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "líense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "líate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "líese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "liémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "liaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "líense"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te líes"
@@ -260,11 +260,11 @@ def test_bañarse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se bañaren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "báñate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "báñese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "bañémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "bañaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "báñense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "báñate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "báñese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "bañémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "bañaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "báñense"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te bañes"

--- a/tests/test_get_conjugation_rae_non_ar_reflexives.py
+++ b/tests/test_get_conjugation_rae_non_ar_reflexives.py
@@ -84,11 +84,11 @@ def test_meterse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se metieren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "métete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "métase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "metámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "meteos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "métanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "métete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "métase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "metámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "meteos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "métanse"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te metas"
@@ -174,11 +174,11 @@ def test_arrepentirse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se arrepintieren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "arrepiéntete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "arrepiéntase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "arrepintámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "arrepentíos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "arrepiéntanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "arrepiéntete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "arrepiéntase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "arrepintámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "arrepentíos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "arrepiéntanse"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te arrepientas"
@@ -264,11 +264,11 @@ def test_irse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se fueren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "vete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "váyase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "vámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "idos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "váyanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "vete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "váyase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "vámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "idos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "váyanse"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te vayas"
@@ -354,11 +354,11 @@ def test_reírse():
     assert out["subjuntivo_futuro"]["3rd_plural"] == "se rieren"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "ríete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "ríase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "riámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "reíos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "ríanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "ríete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "ríase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "riámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "reíos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "ríanse"
 
     # Imperativo negativo
     assert out["imperativo_negativo"]["2nd_singular"] == "no te rías"

--- a/tests/test_get_conjugation_rae_reflexive_fusing.py
+++ b/tests/test_get_conjugation_rae_reflexive_fusing.py
@@ -18,11 +18,11 @@ def test_arrepentirse():
     assert out["gerundio"] == "arrepintiéndose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "arrepiéntete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "arrepiéntase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "arrepintámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "arrepentíos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "arrepiéntanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "arrepiéntete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "arrepiéntase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "arrepintámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "arrepentíos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "arrepiéntanse"
 
 
 def test_bajarse():
@@ -35,11 +35,11 @@ def test_bajarse():
     assert out["gerundio"] == "bajándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "bájate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "bájese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "bajémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "bajaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "bájense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "bájate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "bájese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "bajémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "bajaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "bájense"
 
 
 def test_bañarse():
@@ -51,11 +51,11 @@ def test_bañarse():
     assert out["gerundio"] == "bañándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "báñate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "báñese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "bañémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "bañaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "báñense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "báñate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "báñese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "bañémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "bañaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "báñense"
 
 
 def test_darse():
@@ -67,11 +67,11 @@ def test_darse():
     assert out["gerundio"] == "dándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "date"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "dese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "démonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "daos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "dense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "date"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "dese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "démonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "daos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "dense"
 
 
 def test_echarse():
@@ -84,11 +84,11 @@ def test_echarse():
     assert out["gerundio"] == "echándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "échate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "échese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "echémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "echaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "échense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "échate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "échese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "echémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "echaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "échense"
 
 
 def test_endeudarse():
@@ -101,11 +101,11 @@ def test_endeudarse():
     assert out["gerundio"] == "endeudándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "endéudate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "endéudese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "endeudémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "endeudaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "endéudense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "endéudate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "endéudese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "endeudémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "endeudaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "endéudense"
 
 
 def test_esforzarse():
@@ -118,11 +118,11 @@ def test_esforzarse():
     assert out["gerundio"] == "esforzándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "esfuérzate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "esfuércese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "esforcémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "esforzaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "esfuércense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "esfuérzate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "esfuércese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "esforcémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "esforzaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "esfuércense"
 
 
 def test_fijarse():
@@ -135,11 +135,11 @@ def test_fijarse():
     assert out["gerundio"] == "fijándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "fíjate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "fíjese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "fijémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "fijaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "fíjense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "fíjate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "fíjese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "fijémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "fijaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "fíjense"
 
 
 def test_irse():
@@ -152,11 +152,11 @@ def test_irse():
     assert out["gerundio"] == "yéndose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "vete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "váyase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "vámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "idos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "váyanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "vete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "váyase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "vámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "idos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "váyanse"
 
 
 def test_levantarse():
@@ -169,11 +169,11 @@ def test_levantarse():
     assert out["gerundio"] == "levantándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "levántate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "levántese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "levantémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "levantaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "levántense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "levántate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "levántese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "levantémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "levantaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "levántense"
 
 
 def test_liarse():
@@ -185,11 +185,11 @@ def test_liarse():
     assert out["gerundio"] == "liándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "líate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "líese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "liémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "liaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "líense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "líate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "líese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "liémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "liaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "líense"
 
 
 def test_meterse():
@@ -202,11 +202,11 @@ def test_meterse():
     assert out["gerundio"] == "metiéndose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "métete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "métase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "metámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "meteos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "métanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "métete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "métase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "metámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "meteos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "métanse"
 
 
 def test_quedarse():
@@ -219,11 +219,11 @@ def test_quedarse():
     assert out["gerundio"] == "quedándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "quédate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "quédese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "quedémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "quedaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "quédense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "quédate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "quédese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "quedémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "quedaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "quédense"
 
 
 def test_quejarse():
@@ -236,11 +236,11 @@ def test_quejarse():
     assert out["gerundio"] == "quejándose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "quéjate"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "quéjese"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "quejémonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "quejaos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "quéjense"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "quéjate"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "quéjese"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "quejémonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "quejaos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "quéjense"
 
 
 def test_reírse():
@@ -253,11 +253,11 @@ def test_reírse():
     assert out["gerundio"] == "riéndose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "ríete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "ríase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "riámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "reíos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "ríanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "ríete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "ríase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "riámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "reíos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "ríanse"
 
 
 def test_subirse():
@@ -270,8 +270,8 @@ def test_subirse():
     assert out["gerundio"] == "subiéndose"
 
     # Imperativo afirmativo
-    assert out["imperativo_affirmativo"]["2nd_singular"] == "súbete"
-    assert out["imperativo_affirmativo"]["3rd_singular"] == "súbase"
-    assert out["imperativo_affirmativo"]["1st_plural"] == "subámonos"
-    assert out["imperativo_affirmativo"]["2nd_plural"] == "subíos"
-    assert out["imperativo_affirmativo"]["3rd_plural"] == "súbanse"
+    assert out["imperativo_afirmativo"]["2nd_singular"] == "súbete"
+    assert out["imperativo_afirmativo"]["3rd_singular"] == "súbase"
+    assert out["imperativo_afirmativo"]["1st_plural"] == "subámonos"
+    assert out["imperativo_afirmativo"]["2nd_plural"] == "subíos"
+    assert out["imperativo_afirmativo"]["3rd_plural"] == "súbanse"

--- a/tests/test_regular_form_generator.py
+++ b/tests/test_regular_form_generator.py
@@ -79,11 +79,11 @@ def test_hablar():
     assert gen.generate("hablar", "subjuntivo_futuro", "3rd_plural") == "hablaren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("hablar", "imperativo_affirmativo", "2nd_singular") == "habla"
-    assert gen.generate("hablar", "imperativo_affirmativo", "3rd_singular") == "hable"
-    assert gen.generate("hablar", "imperativo_affirmativo", "1st_plural") == "hablemos"
-    assert gen.generate("hablar", "imperativo_affirmativo", "2nd_plural") == "hablad"
-    assert gen.generate("hablar", "imperativo_affirmativo", "3rd_plural") == "hablen"
+    assert gen.generate("hablar", "imperativo_afirmativo", "2nd_singular") == "habla"
+    assert gen.generate("hablar", "imperativo_afirmativo", "3rd_singular") == "hable"
+    assert gen.generate("hablar", "imperativo_afirmativo", "1st_plural") == "hablemos"
+    assert gen.generate("hablar", "imperativo_afirmativo", "2nd_plural") == "hablad"
+    assert gen.generate("hablar", "imperativo_afirmativo", "3rd_plural") == "hablen"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("hablar", "imperativo_negativo", "2nd_singular") == "no hables"
@@ -164,11 +164,11 @@ def test_deber():
     assert gen.generate("deber", "subjuntivo_futuro", "3rd_plural") == "debieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("deber", "imperativo_affirmativo", "2nd_singular") == "debe"
-    assert gen.generate("deber", "imperativo_affirmativo", "3rd_singular") == "deba"
-    assert gen.generate("deber", "imperativo_affirmativo", "1st_plural") == "debamos"
-    assert gen.generate("deber", "imperativo_affirmativo", "2nd_plural") == "debed"
-    assert gen.generate("deber", "imperativo_affirmativo", "3rd_plural") == "deban"
+    assert gen.generate("deber", "imperativo_afirmativo", "2nd_singular") == "debe"
+    assert gen.generate("deber", "imperativo_afirmativo", "3rd_singular") == "deba"
+    assert gen.generate("deber", "imperativo_afirmativo", "1st_plural") == "debamos"
+    assert gen.generate("deber", "imperativo_afirmativo", "2nd_plural") == "debed"
+    assert gen.generate("deber", "imperativo_afirmativo", "3rd_plural") == "deban"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("deber", "imperativo_negativo", "2nd_singular") == "no debas"
@@ -249,11 +249,11 @@ def test_vivir():
     assert gen.generate("vivir", "subjuntivo_futuro", "3rd_plural") == "vivieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("vivir", "imperativo_affirmativo", "2nd_singular") == "vive"
-    assert gen.generate("vivir", "imperativo_affirmativo", "3rd_singular") == "viva"
-    assert gen.generate("vivir", "imperativo_affirmativo", "1st_plural") == "vivamos"
-    assert gen.generate("vivir", "imperativo_affirmativo", "2nd_plural") == "vivid"
-    assert gen.generate("vivir", "imperativo_affirmativo", "3rd_plural") == "vivan"
+    assert gen.generate("vivir", "imperativo_afirmativo", "2nd_singular") == "vive"
+    assert gen.generate("vivir", "imperativo_afirmativo", "3rd_singular") == "viva"
+    assert gen.generate("vivir", "imperativo_afirmativo", "1st_plural") == "vivamos"
+    assert gen.generate("vivir", "imperativo_afirmativo", "2nd_plural") == "vivid"
+    assert gen.generate("vivir", "imperativo_afirmativo", "3rd_plural") == "vivan"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("vivir", "imperativo_negativo", "2nd_singular") == "no vivas"
@@ -334,11 +334,11 @@ def test_oír():
     assert gen.generate("oír", "subjuntivo_futuro", "3rd_plural") == "oieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("oír", "imperativo_affirmativo", "2nd_singular") == "oe"
-    assert gen.generate("oír", "imperativo_affirmativo", "3rd_singular") == "oa"
-    assert gen.generate("oír", "imperativo_affirmativo", "1st_plural") == "oamos"
-    assert gen.generate("oír", "imperativo_affirmativo", "2nd_plural") == "oid"
-    assert gen.generate("oír", "imperativo_affirmativo", "3rd_plural") == "oan"
+    assert gen.generate("oír", "imperativo_afirmativo", "2nd_singular") == "oe"
+    assert gen.generate("oír", "imperativo_afirmativo", "3rd_singular") == "oa"
+    assert gen.generate("oír", "imperativo_afirmativo", "1st_plural") == "oamos"
+    assert gen.generate("oír", "imperativo_afirmativo", "2nd_plural") == "oid"
+    assert gen.generate("oír", "imperativo_afirmativo", "3rd_plural") == "oan"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("oír", "imperativo_negativo", "2nd_singular") == "no oas"
@@ -544,23 +544,22 @@ def test_levantarse():
 
     # Imperativo afirmativo (no 1st person singular)
     assert (
-        gen.generate("levantarse", "imperativo_affirmativo", "2nd_singular")
+        gen.generate("levantarse", "imperativo_afirmativo", "2nd_singular")
         == "levántate"
     )
     assert (
-        gen.generate("levantarse", "imperativo_affirmativo", "3rd_singular")
+        gen.generate("levantarse", "imperativo_afirmativo", "3rd_singular")
         == "levántese"
     )
     assert (
-        gen.generate("levantarse", "imperativo_affirmativo", "1st_plural")
+        gen.generate("levantarse", "imperativo_afirmativo", "1st_plural")
         == "levantémonos"
     )
     assert (
-        gen.generate("levantarse", "imperativo_affirmativo", "2nd_plural")
-        == "levantaos"
+        gen.generate("levantarse", "imperativo_afirmativo", "2nd_plural") == "levantaos"
     )
     assert (
-        gen.generate("levantarse", "imperativo_affirmativo", "3rd_plural")
+        gen.generate("levantarse", "imperativo_afirmativo", "3rd_plural")
         == "levántense"
     )
 
@@ -670,11 +669,11 @@ def test_reírse():
     assert gen.generate("reírse", "subjuntivo_futuro", "3rd_plural") == "se reieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("reírse", "imperativo_affirmativo", "2nd_singular") == "reete"
-    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_singular") == "rease"
-    assert gen.generate("reírse", "imperativo_affirmativo", "1st_plural") == "reámonos"
-    assert gen.generate("reírse", "imperativo_affirmativo", "2nd_plural") == "reíos"
-    assert gen.generate("reírse", "imperativo_affirmativo", "3rd_plural") == "reanse"
+    assert gen.generate("reírse", "imperativo_afirmativo", "2nd_singular") == "reete"
+    assert gen.generate("reírse", "imperativo_afirmativo", "3rd_singular") == "rease"
+    assert gen.generate("reírse", "imperativo_afirmativo", "1st_plural") == "reámonos"
+    assert gen.generate("reírse", "imperativo_afirmativo", "2nd_plural") == "reíos"
+    assert gen.generate("reírse", "imperativo_afirmativo", "3rd_plural") == "reanse"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("reírse", "imperativo_negativo", "2nd_singular") == "no te reas"
@@ -757,11 +756,11 @@ def test_irse():
     assert gen.generate("irse", "subjuntivo_futuro", "3rd_plural") == "se ieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("irse", "imperativo_affirmativo", "2nd_singular") == "ete"
-    assert gen.generate("irse", "imperativo_affirmativo", "3rd_singular") == "ase"
-    assert gen.generate("irse", "imperativo_affirmativo", "1st_plural") == "ámonos"
-    assert gen.generate("irse", "imperativo_affirmativo", "2nd_plural") == "íos"
-    assert gen.generate("irse", "imperativo_affirmativo", "3rd_plural") == "anse"
+    assert gen.generate("irse", "imperativo_afirmativo", "2nd_singular") == "ete"
+    assert gen.generate("irse", "imperativo_afirmativo", "3rd_singular") == "ase"
+    assert gen.generate("irse", "imperativo_afirmativo", "1st_plural") == "ámonos"
+    assert gen.generate("irse", "imperativo_afirmativo", "2nd_plural") == "íos"
+    assert gen.generate("irse", "imperativo_afirmativo", "3rd_plural") == "anse"
 
     # Imperativo negativo (no 1st person singular)
     assert gen.generate("irse", "imperativo_negativo", "2nd_singular") == "no te as"
@@ -876,13 +875,11 @@ def test_meterse():
     assert gen.generate("meterse", "subjuntivo_futuro", "3rd_plural") == "se metieren"
 
     # Imperativo afirmativo (no 1st person singular)
-    assert gen.generate("meterse", "imperativo_affirmativo", "2nd_singular") == "métete"
-    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_singular") == "métase"
-    assert (
-        gen.generate("meterse", "imperativo_affirmativo", "1st_plural") == "metámonos"
-    )
-    assert gen.generate("meterse", "imperativo_affirmativo", "2nd_plural") == "meteos"
-    assert gen.generate("meterse", "imperativo_affirmativo", "3rd_plural") == "métanse"
+    assert gen.generate("meterse", "imperativo_afirmativo", "2nd_singular") == "métete"
+    assert gen.generate("meterse", "imperativo_afirmativo", "3rd_singular") == "métase"
+    assert gen.generate("meterse", "imperativo_afirmativo", "1st_plural") == "metámonos"
+    assert gen.generate("meterse", "imperativo_afirmativo", "2nd_plural") == "meteos"
+    assert gen.generate("meterse", "imperativo_afirmativo", "3rd_plural") == "métanse"
 
     # Imperativo negativo (no 1st person singular)
     assert (
@@ -900,11 +897,9 @@ def test_meterse():
     assert gen.generate("meterse", "imperativo_negativo", "3rd_plural") == "no se metan"
 
 
-def test_echarse_imperativo_affirmativo():
-    assert gen.generate("echarse", "imperativo_affirmativo", "2nd_singular") == "échate"
-    assert gen.generate("echarse", "imperativo_affirmativo", "3rd_singular") == "échese"
-    assert (
-        gen.generate("echarse", "imperativo_affirmativo", "1st_plural") == "echémonos"
-    )
-    assert gen.generate("echarse", "imperativo_affirmativo", "2nd_plural") == "echaos"
-    assert gen.generate("echarse", "imperativo_affirmativo", "3rd_plural") == "échense"
+def test_echarse_imperativo_afirmativo():
+    assert gen.generate("echarse", "imperativo_afirmativo", "2nd_singular") == "échate"
+    assert gen.generate("echarse", "imperativo_afirmativo", "3rd_singular") == "échese"
+    assert gen.generate("echarse", "imperativo_afirmativo", "1st_plural") == "echémonos"
+    assert gen.generate("echarse", "imperativo_afirmativo", "2nd_plural") == "echaos"
+    assert gen.generate("echarse", "imperativo_afirmativo", "3rd_plural") == "échense"

--- a/utilities/get_conjugation_rae.py
+++ b/utilities/get_conjugation_rae.py
@@ -255,7 +255,7 @@ class RAEConjugationTransformer:
                     if isinstance(form, str) and form.endswith(f" {p}"):
                         mapping[person] = form.replace(f" {p}", p)
                 if (
-                    key == "imperativo_affirmativo"
+                    key == "imperativo_afirmativo"
                     and person == "1st_plural"
                     and isinstance(mapping.get(person), str)
                     and mapping[person].startswith("nos ")
@@ -263,9 +263,9 @@ class RAEConjugationTransformer:
                     base_form = mapping[person][4:]
                     if self.verb.rstrip("se") == "ir":
                         base_form = "vamos"
-                    temp = {"imperativo_affirmativo": {"1st_plural": base_form}}
+                    temp = {"imperativo_afirmativo": {"1st_plural": base_form}}
                     self._add_reflexive(temp)
-                    mapping[person] = temp["imperativo_affirmativo"]["1st_plural"]
+                    mapping[person] = temp["imperativo_afirmativo"]["1st_plural"]
             if not isinstance(value, dict):
                 out[key] = mapping[""]
         if "participio" in out:
@@ -338,7 +338,7 @@ class RAEConjugationTransformer:
                 if person not in mapping:
                     continue
                 form = mapping[person]
-                if key == "imperativo_affirmativo":
+                if key == "imperativo_afirmativo":
                     mapping[person] = attach_affirmative(form, pron)
                 elif key == "imperativo_negativo":
                     if form.startswith("no "):
@@ -373,11 +373,11 @@ class RAEConjugationTransformer:
 
         imperativo = data.get("Imperativo", {})
         if "Imperativo" in imperativo:
-            out["imperativo_affirmativo"] = self._map_personal(imperativo["Imperativo"])
-            if "1st_plural" not in out["imperativo_affirmativo"]:
+            out["imperativo_afirmativo"] = self._map_personal(imperativo["Imperativo"])
+            if "1st_plural" not in out["imperativo_afirmativo"]:
                 subj = out.get("subjuntivo_presente")
                 if isinstance(subj, dict) and "1st_plural" in subj:
-                    out["imperativo_affirmativo"]["1st_plural"] = subj["1st_plural"]
+                    out["imperativo_afirmativo"]["1st_plural"] = subj["1st_plural"]
 
         subj_pres = out.get("subjuntivo_presente")
         if subj_pres:

--- a/utilities/regular_form_generator.py
+++ b/utilities/regular_form_generator.py
@@ -23,7 +23,7 @@ class RegularFormGenerator:
         8: "subjuntivo_presente",
         9: "subjuntivo_imperfecto",
         10: "subjuntivo_futuro",
-        11: "imperativo_affirmativo",
+        11: "imperativo_afirmativo",
         12: "imperativo_negativo",
     }
 
@@ -339,7 +339,7 @@ class RegularFormGenerator:
                     "3rd_plural": "ieren",
                 },
             },
-            "imperativo_affirmativo": {
+            "imperativo_afirmativo": {
                 "ar": {
                     "2nd_singular": "a",
                     "3rd_singular": "e",
@@ -419,7 +419,7 @@ class RegularFormGenerator:
                 base_conjugation = stem + conjugations[form][ending][person]
                 if is_reflexive:
                     pronoun = self.get_reflexive_pronoun(person)
-                    if form == "imperativo_affirmativo":
+                    if form == "imperativo_afirmativo":
                         original = base_conjugation
                         if person == "1st_plural" and base_conjugation.endswith("mos"):
                             base_conjugation = base_conjugation[:-1]

--- a/verb_data/tenses.csv
+++ b/verb_data/tenses.csv
@@ -10,5 +10,5 @@ form_id,form,form_trigger_phrases
 8,subjuntivo_presente,[yo/tú/etc + (present) querer/esperar/desear/preferir + que; ojalá (que); yo/tú/etc + (present) alegrar/molestar/sentir/sorprender/temer/dudar/creer + que; en caso de que; para que; antes de que; a menos que; con tal de que; sin que]
 9,subjuntivo_imperfecto,[yo/tú/etc + (imperfecto) querer/esperar/desear/preferir + que; yo/tú/etc + (imperfecto) alegrar/molestar/sentir/sorprender/temer/dudar/creer + que; era + importante/necesario/una lástima/raro + que; si + (subjuntivo imperfecto) + entronces + (condicional)]
 10,subjuntivo_futuro,[El que lo hiciere; quien hubiere causado daño; el que dijere falsedad; si alguien cometiere fraude; Cualquiera que viniere]
-11,imperativo_affirmativo,[¡Señor(es)!; ¡Señora(s)!; ¡Jefe(s)!]
+11,imperativo_afirmativo,[¡Señor(es)!; ¡Señora(s)!; ¡Jefe(s)!]
 12,imperativo_negativo,[¡Señor(es)!; ¡Señora(s)!; ¡Jefe(s)!]


### PR DESCRIPTION
## Summary
- rename `imperativo_affirmativo` to `imperativo_afirmativo`
- update utilities and generator
- adjust tests and example script
- correct the tenses.csv entry

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efb30c2748329bc44968e40c111bf