### PR TITLE
Add range selection for example sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ produce audio using ElevenLabs.
 - `generate_cards_init.py` builds the initial `cards.csv` combining every
   verb, form and person.
 - `generate_example_sentences.py` adds verified conjugations and example
-  sentences using the OpenAI API.
+  sentences using the OpenAI API. Use `--start-row` and `--end-row` to
+  restrict processing to a subset of `cards.csv`.
 - `generate_audio.py` creates audio files for the sentences with
   ElevenLabs.
 - `utilities/get_conjugation_rae.py` scrapes conjugations from the RAE


### PR DESCRIPTION
## Summary
- allow generate_example_sentences to process a row range via `--start-row` and `--end-row`
- document the new arguments in the README

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685083fca25c8329b18a98f43c5e732e