### PR TITLE
Add row range options to example generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ produce audio using ElevenLabs.
 - `generate_cards_init.py` builds the initial `cards.db` combining every
   verb, form and person.
 - `generate_example_sentences.py` adds verified conjugations and example
-  sentences using the OpenAI API.
+  sentences using the OpenAI API.  Optional `--start` and `--end`
+  arguments limit processing to specific row ranges.
 - `generate_audio.py` creates audio files for the sentences with
   ElevenLabs.
 - `utilities/get_conjugation_rae.py` scrapes conjugations from the RAE


### PR DESCRIPTION
## Summary
- add argparse CLI with `--start` and `--end` options to select row ranges
- document new arguments in README

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850bf50a8fc8329b660855ed46c81fa