### PR TITLE
Add speaker_gender and audio columns to cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ produce audio using ElevenLabs.
 | `conjugation`                      | actual conjugation                                       | `soy`                               |
 | `regularity_class`                 | how the conjugation differs from the regular form (`totally_regular`, `orthographically_irregular`, or `morphologically_irregular`) | `totally_regular` |
 | `sentence`                         | example sentence using the conjugation                   | `Soy capaz de correr un maratón.`   |
+| `speaker_gender`                   | gender of the voice used for audio                       | `male`                              |
 | `audio_path`                       | path to the audio recording of the sentence              | `audio/1_3_11.mp3`                  |
 
 Join the discussion on

--- a/add_columns.py
+++ b/add_columns.py
@@ -1,0 +1,37 @@
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+def add_columns(db_path: str) -> None:
+    """Add speaker_gender and audio_path columns to the cards table."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(cards);")
+        existing_cols = {row[1] for row in cur.fetchall()}
+        if "speaker_gender" not in existing_cols:
+            cur.execute("ALTER TABLE cards ADD COLUMN speaker_gender TEXT;")
+        if "audio_path" not in existing_cols:
+            cur.execute("ALTER TABLE cards ADD COLUMN audio_path TEXT;")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Add speaker_gender and audio_path columns to cards"
+    )
+    parser.add_argument(
+        "--db",
+        default="cards.db",
+        help="Path to the SQLite database (default: cards.db)",
+    )
+    args = parser.parse_args()
+    add_columns(Path(args.db))
+    print("Columns added if missing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_cards_init.py
+++ b/generate_cards_init.py
@@ -59,7 +59,7 @@ NO_IMPERATIVE_VERBS = {
     "caber",
     "yacer",
     "existir",
-    "necesitar"
+    "necesitar",
 }
 
 # verbs that only use third-person forms


### PR DESCRIPTION
## Summary
- create `add_columns.py` for altering `cards` database
- describe new `speaker_gender` field in README
- format codebase with `black`

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c5265b51c832982d4ed3740668e04