### PR TITLE
Add speaker gender and audio columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ produce audio using ElevenLabs.
 | `conjugation`                      | actual conjugation                                       | `soy`                               |
 | `regularity_class`                 | how the conjugation differs from the regular form (`totally_regular`, `orthographically_irregular`, or `morphologically_irregular`) | `totally_regular` |
 | `sentence`                         | example sentence using the conjugation                   | `Soy capaz de correr un maratón.`   |
+| `speaker_gender`                   | gender of the audio voice (e.g. `male`, `female`)         | `male`                              |
 | `audio_path`                       | path to the audio recording of the sentence              | `audio/1_3_11.mp3`                  |
 
 Join the discussion on

--- a/generate_cards_init.py
+++ b/generate_cards_init.py
@@ -33,6 +33,8 @@ FIELDNAMES = [
     "example_sentence",
     "attempts_count",
     "failure_counts",
+    "speaker_gender",
+    "audio_path",
 ]
 
 
@@ -59,7 +61,7 @@ NO_IMPERATIVE_VERBS = {
     "caber",
     "yacer",
     "existir",
-    "necesitar"
+    "necesitar",
 }
 
 # verbs that only use third-person forms
@@ -189,12 +191,14 @@ def generate_conjugation_table():
             regularity_class TEXT,
             example_sentence TEXT,
             attempts_count INTEGER,
-            failure_counts TEXT
+            failure_counts TEXT,
+            speaker_gender TEXT,
+            audio_path TEXT
         )
         """
     )
     cur.executemany(
-        "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "INSERT INTO cards VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         [
             (
                 row["verb_id"],
@@ -210,6 +214,8 @@ def generate_conjugation_table():
                 row["example_sentence"],
                 row["attempts_count"],
                 row["failure_counts"],
+                row["speaker_gender"],
+                row["audio_path"],
             )
             for row in conjugation_table
         ],


### PR DESCRIPTION
## Summary
- include `speaker_gender` and `audio_path` in cards DB initialization
- document the new `speaker_gender` field

## Testing
- `black --check .`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c55b293f483298f1c009cce651bfb